### PR TITLE
Fix Problema de cursor saltarín en campos de texto de iOS

### DIFF
--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/ui/ListaCompraViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/ui/ListaCompraViewModel.kt
@@ -81,7 +81,7 @@ class ListaCompraViewModel(
     private fun saveEditedProduct() {
         val currentState = _state.value
         val editingId = currentState.editingProductId
-        val editingText = currentState.editingText
+        val editingText = currentState.editingText.text
 
         if (editingId != null && editingText.isNotBlank()) {
             val originalProduct = currentState.listaCompraUI.productos.find { it.id == editingId }

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/ui/ListaCompraViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/ui/ListaCompraViewModel.kt
@@ -13,6 +13,7 @@ import dev.bonygod.listacompra.ui.composables.preview.ListaCompraPreview
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import androidx.compose.ui.text.input.TextFieldValue
 
 class ListaCompraViewModel(
     private val getProductosUseCase: GetProductosUseCase,
@@ -115,7 +116,7 @@ class ListaCompraViewModel(
 
     private fun addProducto() {
         val currentState = _state.value
-        val newProductText = currentState.newProductText.trim()
+        val newProductText = currentState.newProductText.text.trim()
 
         if (newProductText.isNotBlank()) {
             viewModelScope.launch {
@@ -124,7 +125,7 @@ class ListaCompraViewModel(
                     setState {
                         copy(
                             showBottomSheet = false,
-                            newProductText = ""
+                            newProductText = TextFieldValue("")
                         )
                     }
                 } catch (e: Exception) {

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/ui/composables/HomeContent.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/ui/composables/HomeContent.kt
@@ -132,7 +132,7 @@ fun HomeContent(
 
     if (state.showBottomSheet) {
         AddProductBottomSheet(
-            newProductText = state.newProductText,
+            state = state,
             onEvent = onEvent,
             onDismiss = { onEvent(ListaCompraEvent.ShowBottomSheet(false)) }
         )

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/ui/composables/components/AddProductBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/ui/composables/components/AddProductBottomSheet.kt
@@ -19,14 +19,14 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.bonygod.listacompra.ui.composables.interactions.ListaCompraEvent
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import dev.bonygod.listacompra.ui.composables.interactions.ListaCompraState
 
 // NOTE: Using ExperimentalMaterial3Api because ModalBottomSheet and related components are currently only available as experimental in Material3.
 // Be aware that future Compose updates may introduce breaking changes. Consider updating to stable APIs when available.
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AddProductBottomSheet(
-    newProductText: String,
+    state: ListaCompraState,
     onEvent: (ListaCompraEvent) -> Unit,
     onDismiss: () -> Unit
 ) {
@@ -49,7 +49,7 @@ fun AddProductBottomSheet(
             )
 
             OutlinedTextField(
-                value = newProductText,
+                value = state.newProductText,
                 onValueChange = { onEvent(ListaCompraEvent.UpdateNewProductText(it)) },
                 label = { Text("Nombre del producto") },
                 modifier = Modifier.fillMaxWidth()
@@ -60,7 +60,7 @@ fun AddProductBottomSheet(
             Button(
                 onClick = { onEvent(ListaCompraEvent.AddProducto) },
                 modifier = Modifier.fillMaxWidth(),
-                enabled = newProductText.isNotBlank(),
+                enabled = state.newProductText.isNotBlank(),
                 colors = ButtonDefaults.buttonColors(
                     containerColor = Color(0xFF00913F)
                 )

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/ui/composables/components/AddProductBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/ui/composables/components/AddProductBottomSheet.kt
@@ -60,7 +60,7 @@ fun AddProductBottomSheet(
             Button(
                 onClick = { onEvent(ListaCompraEvent.AddProducto) },
                 modifier = Modifier.fillMaxWidth(),
-                enabled = state.newProductText.isNotBlank(),
+                enabled = state.newProductText.text.isNotBlank(),
                 colors = ButtonDefaults.buttonColors(
                     containerColor = Color(0xFF00913F)
                 )

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/ui/composables/interactions/ListaCompraEvent.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/ui/composables/interactions/ListaCompraEvent.kt
@@ -1,5 +1,7 @@
 package dev.bonygod.listacompra.ui.composables.interactions
 
+import androidx.compose.ui.text.input.TextFieldValue
+
 sealed class ListaCompraEvent {
     data class BorrarProducto(val productId: String) : ListaCompraEvent()
     data object BorrarTodosLosProductos : ListaCompraEvent()
@@ -14,6 +16,6 @@ sealed class ListaCompraEvent {
     data object HideErrorAlert : ListaCompraEvent()
     data object HideSuccessAlert : ListaCompraEvent()
     data class ShowBottomSheet(val show: Boolean) : ListaCompraEvent()
-    data class UpdateNewProductText(val text: String) : ListaCompraEvent()
+    data class UpdateNewProductText(val text: TextFieldValue) : ListaCompraEvent()
     data object AddProducto : ListaCompraEvent()
 }

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/ui/composables/interactions/ListaCompraEvent.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/ui/composables/interactions/ListaCompraEvent.kt
@@ -10,7 +10,7 @@ sealed class ListaCompraEvent {
     data object ConfirmDelete : ListaCompraEvent()
     data object CancelDialog : ListaCompraEvent()
     data class StartEditingProduct(val productId: String, val currentName: String) : ListaCompraEvent()
-    data class UpdateEditingText(val text: String) : ListaCompraEvent()
+    data class UpdateEditingText(val text: TextFieldValue) : ListaCompraEvent()
     data object SaveEditedProduct : ListaCompraEvent()
     data object CancelEditing : ListaCompraEvent()
     data object HideErrorAlert : ListaCompraEvent()

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/ui/composables/interactions/ListaCompraState.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/ui/composables/interactions/ListaCompraState.kt
@@ -9,7 +9,7 @@ data class ListaCompraState(
     val error: String? = null,
     val listaCompraUI: ListaCompraUI = ListaCompraUI(),
     val editingProductId: String? = null,
-    val editingText: String = "",
+    val editingText: TextFieldValue = TextFieldValue(""),
     val showErrorAlert: Boolean = false,
     val errorAlertTitle: String = "",
     val errorAlertMessage: String = "",
@@ -41,10 +41,10 @@ data class ListaCompraState(
     }
 
     fun startEditingProduct(productId: String, currentName: String): ListaCompraState {
-        return copy(editingProductId = productId, editingText = currentName)
+        return copy(editingProductId = productId, editingText = TextFieldValue(currentName))
     }
 
-    fun updateEditingText(text: String): ListaCompraState {
+    fun updateEditingText(text: TextFieldValue): ListaCompraState {
         return copy(editingText = text)
     }
 
@@ -52,7 +52,7 @@ data class ListaCompraState(
         val editingId = editingProductId ?: return this
         val updatedProductos = listaCompraUI.productos.map { producto ->
             if (producto.id == editingId) {
-                producto.copy(nombre = editingText)
+                producto.copy(nombre = editingText.text)
             } else {
                 producto
             }
@@ -61,7 +61,7 @@ data class ListaCompraState(
         return copy(
             listaCompraUI = updatedListaCompraUI,
             editingProductId = null,
-            editingText = ""
+            editingText = TextFieldValue("")
         )
     }
 
@@ -98,7 +98,7 @@ data class ListaCompraState(
     }
 
     fun cancelEditing(): ListaCompraState {
-        return copy(editingProductId = null, editingText = "")
+        return copy(editingProductId = null, editingText = TextFieldValue(""))
     }
 
     fun showBottomSheet(show: Boolean = false): ListaCompraState {

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/ui/composables/interactions/ListaCompraState.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/ui/composables/interactions/ListaCompraState.kt
@@ -1,5 +1,6 @@
 package dev.bonygod.listacompra.ui.composables.interactions
 
+import androidx.compose.ui.text.input.TextFieldValue
 import dev.bonygod.listacompra.ui.model.ListaCompraUI
 
 data class ListaCompraState(
@@ -16,7 +17,7 @@ data class ListaCompraState(
     val successAlertTitle: String = "",
     val successAlertMessage: String = "",
     val showBottomSheet: Boolean = false,
-    val newProductText: String = ""
+    val newProductText: TextFieldValue = TextFieldValue("")
 ) {
     fun showLoading(show: Boolean = false): ListaCompraState {
         return copy(loadingState = show)
@@ -104,7 +105,7 @@ data class ListaCompraState(
         return copy(showBottomSheet = show)
     }
 
-    fun updateNewProductText(text: String): ListaCompraState {
+    fun updateNewProductText(text: TextFieldValue): ListaCompraState {
         return copy(newProductText = text)
     }
 }


### PR DESCRIPTION
# Problema de cursor saltarín en campos de texto de iOS

## 🐛 Problema
Al escribir en el `OutlinedTextField` del AddProductBottomSheet en iOS, el cursor saltaba a una posición incorrecta después de escribir el segundo carácter, causando que el texto se insertara desordenado.

## 🔧 Solución
Reemplazado `String` con `TextFieldValue` para el manejo del estado de los campos de texto y mantener el posicionamiento correcto del cursor durante las recomposiciones.

## 📝 Cambios Realizados
- Actualizado `newProductText` y `editingText` de `String` a `TextFieldValue` en `ListaCompraState`
- Modificados los eventos `UpdateNewProductText` y `UpdateEditingText` para usar `TextFieldValue`
- Actualizados los métodos del ViewModel para extraer texto usando la propiedad `.text` cuando sea necesario
- Garantizada consistencia entre `AddProductBottomSheet` y `TextFieldComponent` en el manejo del estado

## ✅ Resultado
- Corregido el problema de posicionamiento del cursor en campos de texto de iOS
- Mejorada la experiencia de entrada de texto en Android e iOS
- Mantenido comportamiento consistente entre campos de agregar y editar

## 🧪 Testing
- [x] Entrada de texto funciona correctamente en iOS
- [x] El cursor mantiene la posición correcta durante la escritura
- [x] Funcionalidad de agregar producto funciona como se esperaba
- [x] Funcionalidad de editar producto funciona como se esperaba