### PR TITLE
Añadir Purchase Check

### DIFF
--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/data/datasource/ListaCompraDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/data/datasource/ListaCompraDataSource.kt
@@ -26,7 +26,8 @@ class ListaCompraDataSource(
                     id = documentSnapshot.id,
                     producto = documentSnapshot.get("producto") as? String ?: "",
                     fecha = fechaTimestamp?.timeStampTransform() ?: "",
-                    isImportant = documentSnapshot.get("isImportant") as? Boolean ?: false
+                    isImportant = documentSnapshot.get("isImportant") as? Boolean ?: false,
+                    isPurchased = documentSnapshot.get("isPurchased") as? Boolean ?: false
                 ).toDomain()
             }.sortedBy { producto ->
                 producto.fecha
@@ -34,13 +35,20 @@ class ListaCompraDataSource(
         }
     }
 
-    suspend fun updateProducto(listaId: String, id: String, nombre: String, isImportant: Boolean) {
+    suspend fun updateProducto(
+        listaId: String,
+        id: String,
+        nombre: String,
+        isImportant: Boolean,
+        isPurchased: Boolean
+    ) {
         val productosCollection =
             firebase.collection("lista-compra").document(listaId).collection("productos")
         productosCollection.document(id).set(
             data = mapOf(
                 "producto" to nombre,
-                "isImportant" to isImportant
+                "isImportant" to isImportant,
+                "isPurchased" to isPurchased
             ),
             merge = true
         )

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/data/model/entity/ProductoResponse.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/data/model/entity/ProductoResponse.kt
@@ -7,5 +7,6 @@ data class ProductoResponse(
     val id: String = "",
     val producto: String = "",
     val fecha: String = "",
-    val isImportant: Boolean = false
+    val isImportant: Boolean = false,
+    val isPurchased: Boolean = false
 )

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/data/repository/ProductosRepository.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/data/repository/ProductosRepository.kt
@@ -11,8 +11,14 @@ class ProductosRepository(
         return listaCompraDS.getProductos(listaId)
     }
 
-    suspend fun updateProducto(listaId: String, id: String, nombre: String, isImportant: Boolean) {
-        listaCompraDS.updateProducto(listaId, id, nombre, isImportant)
+    suspend fun updateProducto(
+        listaId: String,
+        id: String,
+        nombre: String,
+        isImportant: Boolean,
+        isPurchased: Boolean
+    ) {
+        listaCompraDS.updateProducto(listaId, id, nombre, isImportant, isPurchased)
     }
 
     suspend fun deleteProducto(listaId: String, id: String) {

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/domain/mapper/ProductoMapper.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/domain/mapper/ProductoMapper.kt
@@ -8,6 +8,7 @@ fun ProductoResponse.toDomain(): Producto {
         id = this.id,
         nombre = this.producto,
         fecha = this.fecha,
-        isImportant = this.isImportant
+        isImportant = this.isImportant,
+        isPurchased = this.isPurchased
     )
 }

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/domain/model/Producto.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/domain/model/Producto.kt
@@ -4,5 +4,6 @@ data class Producto(
     val id: String,
     val nombre: String,
     val fecha: String,
-    val isImportant: Boolean
+    val isImportant: Boolean,
+    val isPurchased: Boolean = false
 )

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/domain/usecase/UpdateProductoUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/domain/usecase/UpdateProductoUseCase.kt
@@ -5,7 +5,13 @@ import dev.bonygod.listacompra.home.data.repository.ProductosRepository
 class UpdateProductoUseCase(
     private val productosRepo: ProductosRepository
 ) {
-    suspend operator fun invoke(listaId: String, id: String, nombre: String, isImportant: Boolean) {
-        productosRepo.updateProducto(listaId, id, nombre, isImportant)
+    suspend operator fun invoke(
+        listaId: String,
+        id: String,
+        nombre: String,
+        isImportant: Boolean,
+        isPurchased: Boolean
+    ) {
+        productosRepo.updateProducto(listaId, id, nombre, isImportant, isPurchased)
     }
 }

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/ui/ListaCompraViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/ui/ListaCompraViewModel.kt
@@ -50,7 +50,7 @@ class ListaCompraViewModel(
     private val analyticsService: AnalyticsService,
     private val getUserUseCase: GetUserUseCase,
     private val logoutUseCase: LogOutUseCase,
-    private val getNotificationsUseCase: GetNotificationsUseCase,
+    getNotificationsUseCase: GetNotificationsUseCase,
     private val shareListaCompraUseCase: ShareListaCompraUseCase,
     private val addSharedListUseCase: AddSharedListUseCase,
     private val deleteNotificationUseCase: DeleteNotificationUseCase,
@@ -195,6 +195,7 @@ class ListaCompraViewModel(
             is ListaCompraEvent.OnDeleteAccountClick -> setState { showDeleteAccountDialog(true) }
             is ListaCompraEvent.DismissDeleteAccountDialog -> setState { showDeleteAccountDialog(false) }
             is ListaCompraEvent.OnDeleteAccountConfirm -> deleteAccount()
+            is ListaCompraEvent.TogglePurchased -> togglePurchased(event.productId)
         }
     }
 
@@ -286,7 +287,8 @@ class ListaCompraViewModel(
         viewModelScope.launch {
             try {
                 val listaId = state.value.user.listaId
-                updateProductoUseCase(listaId, id, nombre, isImportant)
+                val isPurchased = state.value.listaCompraUI.productos.find { it.id == id }?.isPurchased ?: false
+                updateProductoUseCase(listaId, id, nombre, isImportant, isPurchased)
                 analyticsService.logProductoUpdated(nombre, isImportant)
             } catch (e: Exception) {
                 e.printStackTrace()
@@ -307,12 +309,14 @@ class ListaCompraViewModel(
             viewModelScope.launch {
                 try {
                     val listaId = state.value.user.listaId
+                    val isPurchased = originalProduct?.isPurchased ?: false
                     updateProductoUseCase(
                         listaId,
                         editingId,
                         editingText,
-                        false
-                    ) // isImportant = false por defecto
+                        false,
+                        isPurchased
+                    )
                     analyticsService.logProductoUpdated(editingText, false)
                 } catch (e: Exception) {
                     e.printStackTrace()
@@ -389,8 +393,34 @@ class ListaCompraViewModel(
         }
     }
 
-    private fun borrarTodosLosProductos() {
+    private fun togglePurchased(productId: String) {
+        val producto = _state.value.listaCompraUI.productos.find { it.id == productId } ?: return
+        val newIsPurchased = !producto.isPurchased
+        setState { togglePurchased(productId) }
         viewModelScope.launch {
+            try {
+                val listaId = state.value.user.listaId
+                updateProductoUseCase(
+                    listaId,
+                    productId,
+                    producto.nombre,
+                    producto.isImportant,
+                    newIsPurchased
+                )
+            } catch (e: Exception) {
+                e.printStackTrace()
+                setState { togglePurchased(productId) }
+                setState {
+                    showErrorAlert(
+                        "Error al actualizar",
+                        "No se pudo guardar el estado del producto. Verifica tu conexión e inténtalo de nuevo."
+                    )
+                }
+            }
+        }
+    }
+
+    private fun borrarTodosLosProductos() {        viewModelScope.launch {
             try {
                 val listaId = state.value.user.listaId
                 val totalProductos = _state.value.listaCompraUI.productos.size

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/ui/composables/components/TextComponent.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/ui/composables/components/TextComponent.kt
@@ -1,6 +1,5 @@
 package dev.bonygod.listacompra.home.ui.composables.components
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -13,6 +12,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CheckboxDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -21,6 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.bonygod.listacompra.common.ui.theme.PrimaryBlue
@@ -36,17 +38,29 @@ fun TextComponent(
     producto: ProductoUI,
     onEvent: (ListaCompraEvent) -> Unit
 ) {
+    val purchasedGreen = Color(0xFF4CAF50)
+    val borderColor = when {
+        producto.isPurchased -> purchasedGreen
+        else -> PrimaryBlue
+    }
     val backgroundColor = when {
+        producto.isPurchased -> Color(0xFFE8F5E9)
         producto.isImportant -> Color(0xFFFFB3BA)
         else -> Color.White
     }
+    val shape = RoundedCornerShape(18.dp)
 
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .height(70.dp)
-            .border(1.dp, PrimaryBlue, RoundedCornerShape(18.dp))
-            .background(backgroundColor, RoundedCornerShape(18.dp))
+            .border(
+                width = if (producto.isPurchased) 2.dp else 1.dp,
+                color = borderColor,
+                shape = shape
+            )
+            .background(backgroundColor, shape)
+            .clip(shape)
             .pointerInput(producto.id, producto.isImportant) {
                 detectTapGestures(
                     onLongPress = {
@@ -60,13 +74,25 @@ fun TextComponent(
                     }
                 )
             }
-            .padding(horizontal = 16.dp),
+            .padding(horizontal = 8.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
+        Checkbox(
+            checked = producto.isPurchased,
+            onCheckedChange = {
+                onEvent(ListaCompraEvent.TogglePurchased(producto.id))
+            },
+            colors = CheckboxDefaults.colors(
+                checkedColor = purchasedGreen,
+                uncheckedColor = PrimaryBlue
+            )
+        )
         Text(
             text = producto.nombre.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() },
             modifier = Modifier.weight(1f),
-            fontSize = 20.sp
+            fontSize = 20.sp,
+            textDecoration = if (producto.isPurchased) TextDecoration.LineThrough else TextDecoration.None,
+            color = if (producto.isPurchased) Color.Gray else Color.Unspecified
         )
         Spacer(modifier = Modifier.width(8.dp))
         Icon(
@@ -88,5 +114,6 @@ fun TextComponent(
                 .size(20.dp)
                 .clickable { onEvent(ListaCompraEvent.BorrarProducto(producto.id)) }
         )
+        Spacer(modifier = Modifier.width(8.dp))
     }
 }

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/ui/composables/interactions/ListaCompraEvent.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/ui/composables/interactions/ListaCompraEvent.kt
@@ -37,4 +37,5 @@ sealed class ListaCompraEvent {
     data class OnCancelSharedList(val listaId: String) : ListaCompraEvent()
     data object OnDeleteAccountClick: ListaCompraEvent()
     data object OnDeleteAccountConfirm: ListaCompraEvent()
+    data class TogglePurchased(val productId: String) : ListaCompraEvent()
 }

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/ui/composables/interactions/ListaCompraState.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/ui/composables/interactions/ListaCompraState.kt
@@ -149,4 +149,12 @@ data class ListaCompraState(
     fun updateNewProductText(text: TextFieldValue): ListaCompraState {
         return copy(newProductText = text)
     }
+
+    fun togglePurchased(productId: String): ListaCompraState {
+        val updatedProductos = listaCompraUI.productos.map { producto ->
+            if (producto.id == productId) producto.copy(isPurchased = !producto.isPurchased)
+            else producto
+        }
+        return copy(listaCompraUI = listaCompraUI.copy(productos = updatedProductos))
+    }
 }

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/ui/mapper/ProductoUIMapper.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/ui/mapper/ProductoUIMapper.kt
@@ -10,6 +10,7 @@ fun Producto.toUI(): ProductoUI {
         nombre = this.nombre,
         fecha = this.fecha,
         isImportant = this.isImportant,
+        isPurchased = this.isPurchased
     )
 }
 

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/ui/model/ProductoUI.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/ui/model/ProductoUI.kt
@@ -5,5 +5,6 @@ data class ProductoUI(
     val nombre: String = "",
     val fecha: String = "",
     val isImportant: Boolean = false,
-    val unidades: Int = 0
+    val unidades: Int = 0,
+    val isPurchased: Boolean = false
 )


### PR DESCRIPTION
## 📋 Descripción

Implementación completa del check de compra en cada producto de la lista, con persistencia en Firestore.

---

## ✅ Cambios realizados

### 🎨 UI — `TextComponent.kt`
- Añadido **checkbox verde** a la izquierda de cada producto
- Cuando el producto está comprado:
  - Se muestra un **borde verde** (2dp) alrededor del item
  - El texto aparece **tachado** y en color gris
  - El fondo cambia a **verde claro**
- Cuando no está comprado, el borde es azul (color normal)

### 🗃️ Persistencia — Firestore
- **`ListaCompraDataSource.kt`**: Lee el campo `isPurchased` de Firestore y lo incluye en el `updateProducto()` al hacer merge
- **`ProductoResponse.kt`**: Añadido campo `isPurchased: Boolean`
- **`ProductosRepository.kt`**: Expone `isPurchased` en `updateProducto()`

### 🏛️ Dominio
- **`Producto.kt`**: Añadido campo `isPurchased: Boolean`
- **`ProductoMapper.kt`**: Mapea `isPurchased` de respuesta a dominio
- **`UpdateProductoUseCase.kt`**: Parámetro `isPurchased` añadido (sin valor por defecto, consistente con `isImportant`)

### 🖼️ UI Model / Mapper
- **`ProductoUI.kt`**: Añadido campo `isPurchased: Boolean = false`
- **`ProductoUIMapper.kt`**: Mapea `isPurchased` de dominio a UI

### 🎬 ViewModel & Estado
- **`ListaCompraEvent.kt`**: Nuevo evento `TogglePurchased(productId: String)`
- **`ListaCompraState.kt`**: Función `togglePurchased()` para actualización optimista local
- **`ListaCompraViewModel.kt`**: Maneja `TogglePurchased` con update optimista + persistencia en Firestore (revierte si falla)

---

## 🔄 Flujo completo

```
Usuario toca checkbox
    → TogglePurchased event
    → Update optimista en estado local (feedback inmediato)
    → UpdateProductoUseCase → Repository → DataSource
    → Firestore actualiza isPurchased
    → Listener en tiempo real confirma el cambio
    → (Si falla: revierte el estado local)
```

---

## ⚠️ Notas
- La fuente de verdad es **Firestore**: el campo `isPurchased` se sincroniza en tiempo real entre todos los usuarios de una lista compartida
- Los productos nuevos se crean con `isPurchased = false` implícitamente al no incluirlo en el `addProducto`