### PR TITLE
fix: deshabilitar orientación landscape en iOS

### DIFF
--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -53,15 +53,11 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>


### PR DESCRIPTION
## Descripción

Deshabilita la orientación landscape en iOS para evitar que el banner de AdMob se muestre a pantalla completa sin botón de cierre al rotar el dispositivo.

## Cambios

- **`iosApp/iosApp/Info.plist`**: Eliminadas las orientaciones `UIInterfaceOrientationLandscapeLeft` y `UIInterfaceOrientationLandscapeRight` tanto para iPhone como para iPad.

## Motivación

Al girar el dispositivo en horizontal, el SDK de AdMob mostraba el banner en pantalla completa y el usuario no podía cerrarlo. Restringiendo la app a solo orientación portrait se elimina completamente este comportamiento.