### PR TITLE
develop into main (v1.0.2)

### DIFF
--- a/composeApp/src/commonMain/composeResources/drawable/listas.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/listas.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M280,360v-80h560v80L280,360ZM280,520v-80h560v80L280,520ZM280,680v-80h560v80L280,680ZM160,360q-17,0 -28.5,-11.5T120,320q0,-17 11.5,-28.5T160,280q17,0 28.5,11.5T200,320q0,17 -11.5,28.5T160,360ZM160,520q-17,0 -28.5,-11.5T120,480q0,-17 11.5,-28.5T160,440q17,0 28.5,11.5T200,480q0,17 -11.5,28.5T160,520ZM160,680q-17,0 -28.5,-11.5T120,640q0,-17 11.5,-28.5T160,600q17,0 28.5,11.5T200,640q0,17 -11.5,28.5T160,680Z"
+      android:fillColor="#e3e3e3"/>
+</vector>

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/core/di/NetworkModule.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/core/di/NetworkModule.kt
@@ -27,6 +27,11 @@ import dev.bonygod.listacompra.login.domain.usecase.ShareListaCompraUseCase
 import dev.bonygod.listacompra.login.domain.usecase.UserLoginUseCase
 import dev.bonygod.listacompra.login.domain.usecase.UserRegisterUseCase
 import dev.bonygod.listacompra.login.ui.AuthViewModel
+import dev.bonygod.listacompra.mislistas.domain.usecase.AddNewListaUseCase
+import dev.bonygod.listacompra.mislistas.domain.usecase.GetListasUseCase
+import dev.bonygod.listacompra.mislistas.domain.usecase.RenameListaUseCase
+import dev.bonygod.listacompra.mislistas.domain.usecase.SetDefaultListaUseCase
+import dev.bonygod.listacompra.mislistas.ui.MisListasViewModel
 import org.koin.core.context.startKoin
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.core.qualifier.named
@@ -50,6 +55,7 @@ val appModule = module {
 val viewModelsModule = module {
     viewModelOf(::ListaCompraViewModel)
     viewModelOf(::AuthViewModel)
+    viewModelOf(::MisListasViewModel)
 }
 
 val dataModule = module {
@@ -70,6 +76,10 @@ val dataModule = module {
     single { DeleteNotificationUseCase(get()) }
     single { DeleteAccountUseCase(get()) }
     single { SharedState() }
+    single { GetListasUseCase(get()) }
+    single { SetDefaultListaUseCase(get()) }
+    single { RenameListaUseCase(get()) }
+    single { AddNewListaUseCase(get()) }
 }
 
 fun initKoin(config: KoinAppDeclaration? = null) {

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/core/navigation/NavigationWrapper.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/core/navigation/NavigationWrapper.kt
@@ -13,6 +13,7 @@ import dev.bonygod.listacompra.login.ui.screens.AdLoadingScreen
 import dev.bonygod.listacompra.login.ui.screens.ForgotPasswordScreen
 import dev.bonygod.listacompra.login.ui.screens.LoginScreen
 import dev.bonygod.listacompra.login.ui.screens.RegisterScreen
+import dev.bonygod.listacompra.mislistas.ui.screens.MisListasScreen
 import org.koin.compose.koinInject
 
 @Composable
@@ -39,6 +40,9 @@ fun NavigationWrapper(snackbarHostState: SnackbarHostState) {
             entry<Routes.Home> { entry ->
                 val userId = entry.userId
                 HomeScreen(snackbarHostState = snackbarHostState, userId)
+            }
+            entry<Routes.MisListas> {
+                MisListasScreen()
             }
         },
         transitionSpec = {

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/core/navigation/Routes.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/core/navigation/Routes.kt
@@ -6,4 +6,5 @@ sealed class Routes {
     data object Register : Routes()
     data class Home(val userId: String) : Routes()
     data class AdLoading(val userId: String) : Routes()
+    data object MisListas : Routes()
 }

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/data/datasource/ListaCompraDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/data/datasource/ListaCompraDataSource.kt
@@ -26,7 +26,8 @@ class ListaCompraDataSource(
                     id = documentSnapshot.id,
                     producto = documentSnapshot.get("producto") as? String ?: "",
                     fecha = fechaTimestamp?.timeStampTransform() ?: "",
-                    isImportant = documentSnapshot.get("isImportant") as? Boolean ?: false
+                    isImportant = documentSnapshot.get("isImportant") as? Boolean ?: false,
+                    isPurchased = documentSnapshot.get("isPurchased") as? Boolean ?: false
                 ).toDomain()
             }.sortedBy { producto ->
                 producto.fecha
@@ -34,13 +35,20 @@ class ListaCompraDataSource(
         }
     }
 
-    suspend fun updateProducto(listaId: String, id: String, nombre: String, isImportant: Boolean) {
+    suspend fun updateProducto(
+        listaId: String,
+        id: String,
+        nombre: String,
+        isImportant: Boolean,
+        isPurchased: Boolean
+    ) {
         val productosCollection =
             firebase.collection("lista-compra").document(listaId).collection("productos")
         productosCollection.document(id).set(
             data = mapOf(
                 "producto" to nombre,
-                "isImportant" to isImportant
+                "isImportant" to isImportant,
+                "isPurchased" to isPurchased
             ),
             merge = true
         )

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/data/model/entity/ProductoResponse.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/data/model/entity/ProductoResponse.kt
@@ -7,5 +7,6 @@ data class ProductoResponse(
     val id: String = "",
     val producto: String = "",
     val fecha: String = "",
-    val isImportant: Boolean = false
+    val isImportant: Boolean = false,
+    val isPurchased: Boolean = false
 )

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/data/repository/ProductosRepository.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/data/repository/ProductosRepository.kt
@@ -11,8 +11,14 @@ class ProductosRepository(
         return listaCompraDS.getProductos(listaId)
     }
 
-    suspend fun updateProducto(listaId: String, id: String, nombre: String, isImportant: Boolean) {
-        listaCompraDS.updateProducto(listaId, id, nombre, isImportant)
+    suspend fun updateProducto(
+        listaId: String,
+        id: String,
+        nombre: String,
+        isImportant: Boolean,
+        isPurchased: Boolean
+    ) {
+        listaCompraDS.updateProducto(listaId, id, nombre, isImportant, isPurchased)
     }
 
     suspend fun deleteProducto(listaId: String, id: String) {

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/domain/mapper/ProductoMapper.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/domain/mapper/ProductoMapper.kt
@@ -8,6 +8,7 @@ fun ProductoResponse.toDomain(): Producto {
         id = this.id,
         nombre = this.producto,
         fecha = this.fecha,
-        isImportant = this.isImportant
+        isImportant = this.isImportant,
+        isPurchased = this.isPurchased
     )
 }

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/domain/model/Producto.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/domain/model/Producto.kt
@@ -4,5 +4,6 @@ data class Producto(
     val id: String,
     val nombre: String,
     val fecha: String,
-    val isImportant: Boolean
+    val isImportant: Boolean,
+    val isPurchased: Boolean = false
 )

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/domain/usecase/UpdateProductoUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/domain/usecase/UpdateProductoUseCase.kt
@@ -5,7 +5,13 @@ import dev.bonygod.listacompra.home.data.repository.ProductosRepository
 class UpdateProductoUseCase(
     private val productosRepo: ProductosRepository
 ) {
-    suspend operator fun invoke(listaId: String, id: String, nombre: String, isImportant: Boolean) {
-        productosRepo.updateProducto(listaId, id, nombre, isImportant)
+    suspend operator fun invoke(
+        listaId: String,
+        id: String,
+        nombre: String,
+        isImportant: Boolean,
+        isPurchased: Boolean
+    ) {
+        productosRepo.updateProducto(listaId, id, nombre, isImportant, isPurchased)
     }
 }

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/ui/ListaCompraViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/ui/ListaCompraViewModel.kt
@@ -16,6 +16,7 @@ import dev.bonygod.listacompra.home.ui.composables.interactions.ListaCompraEffec
 import dev.bonygod.listacompra.home.ui.composables.interactions.ListaCompraEvent
 import dev.bonygod.listacompra.home.ui.composables.interactions.ListaCompraState
 import dev.bonygod.listacompra.home.ui.mapper.toUI
+import dev.bonygod.listacompra.home.ui.model.ListaCompraUI
 import dev.bonygod.listacompra.login.domain.usecase.AddSharedListUseCase
 import dev.bonygod.listacompra.login.domain.usecase.DeleteAccountUseCase
 import dev.bonygod.listacompra.login.domain.usecase.DeleteNotificationUseCase
@@ -23,6 +24,7 @@ import dev.bonygod.listacompra.login.domain.usecase.GetNotificationsUseCase
 import dev.bonygod.listacompra.login.domain.usecase.GetUserUseCase
 import dev.bonygod.listacompra.login.domain.usecase.LogOutUseCase
 import dev.bonygod.listacompra.login.domain.usecase.ShareListaCompraUseCase
+import dev.bonygod.listacompra.mislistas.domain.usecase.GetListasUseCase
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -31,6 +33,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.shareIn
@@ -54,7 +57,8 @@ class ListaCompraViewModel(
     private val shareListaCompraUseCase: ShareListaCompraUseCase,
     private val addSharedListUseCase: AddSharedListUseCase,
     private val deleteNotificationUseCase: DeleteNotificationUseCase,
-    private val deleteAccountUseCase: DeleteAccountUseCase
+    private val deleteAccountUseCase: DeleteAccountUseCase,
+    private val getListasUseCase: GetListasUseCase
 ) : ViewModel() {
     private var notificationsJob: Job? = null
     private var productosJob: Job? = null
@@ -69,19 +73,22 @@ class ListaCompraViewModel(
         .flatMapLatest { listaId ->
             if (listaId != null) {
                 getProductosUseCase(listaId)
+                    .catch { emit(ListaCompraUI()) }
             } else {
                 emptyFlow()
             }
         }
+        .catch { emit(ListaCompraUI()) }
         .shareIn(
             scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5000),
+            started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 0),
             replay = 1
         )
     private val sharedNotificationsFlow = getNotificationsUseCase()
+        .catch { emit(emptyList()) }
         .shareIn(
             scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5000),
+            started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 0),
             replay = 1
         )
 
@@ -116,6 +123,15 @@ class ListaCompraViewModel(
 
                         // Actualiza el listaId para activar el flow compartido
                         _currentListaId.value = usuario.listas[0]
+
+                        // Obtiene el nombre de la lista activa
+                        getListasUseCase().fold(
+                            onSuccess = { listas ->
+                                val nombre = listas.firstOrNull()?.nombre ?: "Lista de la compra"
+                                setState { setListaNombre(nombre) }
+                            },
+                            onFailure = { /* mantiene el nombre por defecto */ }
+                        )
 
                         // Suscribirse al flow compartido de productos
                         productosJob = viewModelScope.launch {
@@ -196,15 +212,17 @@ class ListaCompraViewModel(
             is ListaCompraEvent.DismissDeleteAccountDialog -> setState { showDeleteAccountDialog(false) }
             is ListaCompraEvent.OnDeleteAccountConfirm -> deleteAccount()
             is ListaCompraEvent.TogglePurchased -> togglePurchased(event.productId)
+            is ListaCompraEvent.OnMisListasClick -> navigator.navigateTo(Routes.MisListas)
         }
     }
 
     private fun deleteAccount() {
         viewModelScope.launch {
+            // Parar listeners ANTES de borrar la cuenta
+            stopNotificationsListener()
             deleteAccountUseCase()
             setState { showDeleteAccountDialog(false) }
             sharedState.showLoading(false)
-            stopNotificationsListener()
             setState { ListaCompraState() }
             navigator.clearAndNavigateTo(Routes.Login)
         }
@@ -220,11 +238,12 @@ class ListaCompraViewModel(
     private fun acceptSharedList(listaId: String) {
         viewModelScope.launch {
             addSharedListUseCase(listaId).fold(
-                onSuccess = { user ->
+                onSuccess = {
                     deleteNotificationUseCase(listaId)
                     setState { showNotificationBottomSheet(false) }
-                    // Actualiza el listaId para que el flow compartido se suscriba a la nueva lista
-                    _currentListaId.value = user.listas[0]
+                    // Recarga todos los datos del usuario para que los permisos de Firestore
+                    // estén propagados antes de suscribirse a la nueva lista
+                    loadUserData()
                 },
                 onFailure = { error ->
                     val errorMessage = (error as? Exception)?.message ?: "Error desconocido"
@@ -275,9 +294,10 @@ class ListaCompraViewModel(
 
     private fun logOut() {
         viewModelScope.launch {
+            // Parar listeners ANTES de cerrar sesión para evitar PERMISSION_DENIED
+            stopNotificationsListener()
             logoutUseCase()
             sharedState.showLoading(false)
-            stopNotificationsListener()
             setState { ListaCompraState() }
             navigator.clearAndNavigateTo(Routes.Login)
         }

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/ui/ListaCompraViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/ui/ListaCompraViewModel.kt
@@ -50,7 +50,7 @@ class ListaCompraViewModel(
     private val analyticsService: AnalyticsService,
     private val getUserUseCase: GetUserUseCase,
     private val logoutUseCase: LogOutUseCase,
-    private val getNotificationsUseCase: GetNotificationsUseCase,
+    getNotificationsUseCase: GetNotificationsUseCase,
     private val shareListaCompraUseCase: ShareListaCompraUseCase,
     private val addSharedListUseCase: AddSharedListUseCase,
     private val deleteNotificationUseCase: DeleteNotificationUseCase,
@@ -195,6 +195,7 @@ class ListaCompraViewModel(
             is ListaCompraEvent.OnDeleteAccountClick -> setState { showDeleteAccountDialog(true) }
             is ListaCompraEvent.DismissDeleteAccountDialog -> setState { showDeleteAccountDialog(false) }
             is ListaCompraEvent.OnDeleteAccountConfirm -> deleteAccount()
+            is ListaCompraEvent.TogglePurchased -> togglePurchased(event.productId)
         }
     }
 
@@ -286,7 +287,8 @@ class ListaCompraViewModel(
         viewModelScope.launch {
             try {
                 val listaId = state.value.user.listaId
-                updateProductoUseCase(listaId, id, nombre, isImportant)
+                val isPurchased = state.value.listaCompraUI.productos.find { it.id == id }?.isPurchased ?: false
+                updateProductoUseCase(listaId, id, nombre, isImportant, isPurchased)
                 analyticsService.logProductoUpdated(nombre, isImportant)
             } catch (e: Exception) {
                 e.printStackTrace()
@@ -307,12 +309,14 @@ class ListaCompraViewModel(
             viewModelScope.launch {
                 try {
                     val listaId = state.value.user.listaId
+                    val isPurchased = originalProduct?.isPurchased ?: false
                     updateProductoUseCase(
                         listaId,
                         editingId,
                         editingText,
-                        false
-                    ) // isImportant = false por defecto
+                        false,
+                        isPurchased
+                    )
                     analyticsService.logProductoUpdated(editingText, false)
                 } catch (e: Exception) {
                     e.printStackTrace()
@@ -389,8 +393,34 @@ class ListaCompraViewModel(
         }
     }
 
-    private fun borrarTodosLosProductos() {
+    private fun togglePurchased(productId: String) {
+        val producto = _state.value.listaCompraUI.productos.find { it.id == productId } ?: return
+        val newIsPurchased = !producto.isPurchased
+        setState { togglePurchased(productId) }
         viewModelScope.launch {
+            try {
+                val listaId = state.value.user.listaId
+                updateProductoUseCase(
+                    listaId,
+                    productId,
+                    producto.nombre,
+                    producto.isImportant,
+                    newIsPurchased
+                )
+            } catch (e: Exception) {
+                e.printStackTrace()
+                setState { togglePurchased(productId) }
+                setState {
+                    showErrorAlert(
+                        "Error al actualizar",
+                        "No se pudo guardar el estado del producto. Verifica tu conexión e inténtalo de nuevo."
+                    )
+                }
+            }
+        }
+    }
+
+    private fun borrarTodosLosProductos() {        viewModelScope.launch {
             try {
                 val listaId = state.value.user.listaId
                 val totalProductos = _state.value.listaCompraUI.productos.size

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/ui/composables/HomeContent.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/ui/composables/HomeContent.kt
@@ -76,7 +76,7 @@ fun HomeContent(
         ) {
             TopAppBar(
                 colors = TopAppBarDefaults.topAppBarColors(containerColor = SecondaryBlue),
-                title = { Text(text = "Lista de la compra") },
+                title = { Text(text = state.listaNombre, fontWeight = Bold) },
                 navigationIcon = {
                     IconButton(
                         onClick = {

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/ui/composables/components/MenuLateral.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/ui/composables/components/MenuLateral.kt
@@ -22,6 +22,7 @@ import dev.bonygod.listacompra.home.ui.composables.interactions.ListaCompraState
 import listacompra.composeapp.generated.resources.Inter_Italic
 import listacompra.composeapp.generated.resources.Res
 import listacompra.composeapp.generated.resources.basura_black
+import listacompra.composeapp.generated.resources.listas
 import listacompra.composeapp.generated.resources.logout
 import listacompra.composeapp.generated.resources.notification_blank
 import listacompra.composeapp.generated.resources.notification_with_noti
@@ -66,7 +67,29 @@ fun MenuLateral(
             text = state.user.email
         )
         Row(
-            modifier = Modifier.padding(start = 10.dp, top = 50.dp)
+            modifier = Modifier.padding(start = 10.dp, top = 30.dp)
+                .clickable {
+                    setEvent(ListaCompraEvent.OnMisListasClick)
+                    onCloseDrawer()
+                },
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                painter = painterResource(Res.drawable.listas),
+                tint = Color.Gray,
+                contentDescription = "Mis listas",
+            )
+            Text(
+                modifier = Modifier.padding(start = 5.dp),
+                fontFamily = FontFamily(Font(Res.font.Inter_Italic)),
+                fontWeight = FontWeight.Bold,
+                color = Color.Gray,
+                text = "Mis listas"
+            )
+        }
+        Row(
+            modifier = Modifier.padding(start = 10.dp, top = 30.dp)
                 .clickable {
                     setEvent(ListaCompraEvent.OnShareListClick)
                     onCloseDrawer()

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/ui/composables/components/TextComponent.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/ui/composables/components/TextComponent.kt
@@ -1,6 +1,5 @@
 package dev.bonygod.listacompra.home.ui.composables.components
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -13,6 +12,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CheckboxDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -21,6 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.bonygod.listacompra.common.ui.theme.PrimaryBlue
@@ -36,17 +38,29 @@ fun TextComponent(
     producto: ProductoUI,
     onEvent: (ListaCompraEvent) -> Unit
 ) {
+    val purchasedGreen = Color(0xFF4CAF50)
+    val borderColor = when {
+        producto.isPurchased -> purchasedGreen
+        else -> PrimaryBlue
+    }
     val backgroundColor = when {
+        producto.isPurchased -> Color(0xFFE8F5E9)
         producto.isImportant -> Color(0xFFFFB3BA)
         else -> Color.White
     }
+    val shape = RoundedCornerShape(18.dp)
 
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .height(70.dp)
-            .border(1.dp, PrimaryBlue, RoundedCornerShape(18.dp))
-            .background(backgroundColor, RoundedCornerShape(18.dp))
+            .border(
+                width = if (producto.isPurchased) 2.dp else 1.dp,
+                color = borderColor,
+                shape = shape
+            )
+            .background(backgroundColor, shape)
+            .clip(shape)
             .pointerInput(producto.id, producto.isImportant) {
                 detectTapGestures(
                     onLongPress = {
@@ -60,13 +74,25 @@ fun TextComponent(
                     }
                 )
             }
-            .padding(horizontal = 16.dp),
+            .padding(horizontal = 8.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
+        Checkbox(
+            checked = producto.isPurchased,
+            onCheckedChange = {
+                onEvent(ListaCompraEvent.TogglePurchased(producto.id))
+            },
+            colors = CheckboxDefaults.colors(
+                checkedColor = purchasedGreen,
+                uncheckedColor = PrimaryBlue
+            )
+        )
         Text(
             text = producto.nombre.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() },
             modifier = Modifier.weight(1f),
-            fontSize = 20.sp
+            fontSize = 20.sp,
+            textDecoration = if (producto.isPurchased) TextDecoration.LineThrough else TextDecoration.None,
+            color = if (producto.isPurchased) Color.Gray else Color.Unspecified
         )
         Spacer(modifier = Modifier.width(8.dp))
         Icon(
@@ -88,5 +114,6 @@ fun TextComponent(
                 .size(20.dp)
                 .clickable { onEvent(ListaCompraEvent.BorrarProducto(producto.id)) }
         )
+        Spacer(modifier = Modifier.width(8.dp))
     }
 }

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/ui/composables/interactions/ListaCompraEvent.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/ui/composables/interactions/ListaCompraEvent.kt
@@ -37,4 +37,5 @@ sealed class ListaCompraEvent {
     data class OnCancelSharedList(val listaId: String) : ListaCompraEvent()
     data object OnDeleteAccountClick: ListaCompraEvent()
     data object OnDeleteAccountConfirm: ListaCompraEvent()
+    data class TogglePurchased(val productId: String) : ListaCompraEvent()
 }

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/ui/composables/interactions/ListaCompraEvent.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/ui/composables/interactions/ListaCompraEvent.kt
@@ -38,4 +38,5 @@ sealed class ListaCompraEvent {
     data object OnDeleteAccountClick: ListaCompraEvent()
     data object OnDeleteAccountConfirm: ListaCompraEvent()
     data class TogglePurchased(val productId: String) : ListaCompraEvent()
+    data object OnMisListasClick : ListaCompraEvent()
 }

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/ui/composables/interactions/ListaCompraState.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/ui/composables/interactions/ListaCompraState.kt
@@ -149,4 +149,12 @@ data class ListaCompraState(
     fun updateNewProductText(text: TextFieldValue): ListaCompraState {
         return copy(newProductText = text)
     }
+
+    fun togglePurchased(productId: String): ListaCompraState {
+        val updatedProductos = listaCompraUI.productos.map { producto ->
+            if (producto.id == productId) producto.copy(isPurchased = !producto.isPurchased)
+            else producto
+        }
+        return copy(listaCompraUI = listaCompraUI.copy(productos = updatedProductos))
+    }
 }

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/ui/composables/interactions/ListaCompraState.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/ui/composables/interactions/ListaCompraState.kt
@@ -12,6 +12,7 @@ data class ListaCompraState(
     val error: String? = null,
     val listaCompraUI: ListaCompraUI = ListaCompraUI(),
     val user: UserUI = UserUI(),
+    val listaNombre: String = "Lista de la compra",
     val editingProductId: String? = null,
     val editingText: TextFieldValue = TextFieldValue(""),
     val showErrorAlert: Boolean = false,
@@ -55,6 +56,10 @@ data class ListaCompraState(
 
     fun setUser(user: UserUI): ListaCompraState {
         return copy(user = user)
+    }
+
+    fun setListaNombre(nombre: String): ListaCompraState {
+        return copy(listaNombre = nombre)
     }
 
     fun showDialog(show: Boolean = false): ListaCompraState {

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/ui/mapper/ProductoUIMapper.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/ui/mapper/ProductoUIMapper.kt
@@ -10,6 +10,7 @@ fun Producto.toUI(): ProductoUI {
         nombre = this.nombre,
         fecha = this.fecha,
         isImportant = this.isImportant,
+        isPurchased = this.isPurchased
     )
 }
 

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/ui/model/ProductoUI.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/home/ui/model/ProductoUI.kt
@@ -5,5 +5,6 @@ data class ProductoUI(
     val nombre: String = "",
     val fecha: String = "",
     val isImportant: Boolean = false,
-    val unidades: Int = 0
+    val unidades: Int = 0,
+    val isPurchased: Boolean = false
 )

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/login/data/datasource/UsersDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/login/data/datasource/UsersDataSource.kt
@@ -4,6 +4,7 @@ import dev.bonygod.listacompra.login.data.model.NotificationsReponse
 import dev.bonygod.listacompra.login.data.model.UserResponse
 import dev.bonygod.listacompra.login.domain.mapper.toDomain
 import dev.bonygod.listacompra.login.domain.model.Notifications
+import dev.bonygod.listacompra.mislistas.domain.model.ListaInfo
 import dev.gitlive.firebase.auth.FirebaseAuth
 import dev.gitlive.firebase.auth.FirebaseUser
 import dev.gitlive.firebase.firestore.FirebaseFirestore
@@ -272,5 +273,89 @@ class UsersDataSource(
             }
         }
         logOut()
+    }
+
+    /**
+     * Obtener info de todas las listas del usuario.
+     * El nombre se lee primero del mapa `nombresListas` en el doc del usuario
+     * (que el usuario siempre puede escribir), y hace fallback al doc de lista-compra.
+     */
+    suspend fun getListas(): List<ListaInfo> {
+        val userUID = auth.currentUser?.uid.orEmpty()
+        val userDoc = firebase.collection("usuarios").document(userUID).get()
+        val listaIds = (userDoc.get("listas") as? List<String>) ?: emptyList()
+        val defaultListaId = listaIds.firstOrNull() ?: ""
+        @Suppress("UNCHECKED_CAST")
+        val nombresListas = (userDoc.get("nombresListas") as? Map<String, String>) ?: emptyMap()
+
+        return listaIds.mapIndexed { index, listaId ->
+            val nombre = nombresListas[listaId] ?: try {
+                val listaDoc = firebase.collection("lista-compra").document(listaId).get()
+                listaDoc.get("nombre") as? String ?: "Lista ${index + 1}"
+            } catch (e: Exception) {
+                "Lista ${index + 1}"
+            }
+            ListaInfo(id = listaId, nombre = nombre, isDefault = listaId == defaultListaId)
+        }
+    }
+
+    /**
+     * Establecer una lista como predeterminada (mueve al inicio del array en Firestore)
+     */
+    suspend fun setDefaultLista(listaId: String) {
+        val userUID = auth.currentUser?.uid.orEmpty()
+        val userDoc = firebase.collection("usuarios").document(userUID).get()
+        val currentListas = (userDoc.get("listas") as? List<String>) ?: emptyList()
+        if (!currentListas.contains(listaId)) return
+        val reordered = listOf(listaId) + currentListas.filter { it != listaId }
+        firebase.collection("usuarios").document(userUID).set(
+            data = mapOf("listas" to reordered),
+            merge = true
+        )
+    }
+
+    /**
+     * Renombrar una lista.
+     * Guarda el nombre en `usuarios/{uid}.nombresListas` para evitar problemas
+     * de permisos en `lista-compra/{listaId}` (documentos sin campo owner, listas compartidas…)
+     */
+    suspend fun renameNombreLista(listaId: String, nombre: String) {
+        val userUID = auth.currentUser?.uid.orEmpty()
+        val userDoc = firebase.collection("usuarios").document(userUID).get()
+        @Suppress("UNCHECKED_CAST")
+        val currentNombres = (userDoc.get("nombresListas") as? Map<String, String>) ?: emptyMap()
+        val updatedNombres = currentNombres + (listaId to nombre)
+        firebase.collection("usuarios").document(userUID).set(
+            data = mapOf("nombresListas" to updatedNombres),
+            merge = true
+        )
+    }
+
+    /**
+     * Crear una nueva lista y añadirla al usuario.
+     * También guarda el nombre inicial en `nombresListas`.
+     */
+    suspend fun addNewLista(nombre: String): ListaInfo {
+        val userUID = auth.currentUser?.uid.orEmpty()
+        val docRef = firebase.collection("lista-compra").add(
+            mapOf(
+                "createdAt" to Timestamp.now(),
+                "owner" to userUID,
+                "nombre" to nombre
+            )
+        )
+        val newListaId = docRef.id
+        val userDoc = firebase.collection("usuarios").document(userUID).get()
+        val currentListas = (userDoc.get("listas") as? List<String>) ?: emptyList()
+        @Suppress("UNCHECKED_CAST")
+        val currentNombres = (userDoc.get("nombresListas") as? Map<String, String>) ?: emptyMap()
+        firebase.collection("usuarios").document(userUID).set(
+            data = mapOf(
+                "listas" to (currentListas + newListaId),
+                "nombresListas" to (currentNombres + (newListaId to nombre))
+            ),
+            merge = true
+        )
+        return ListaInfo(id = newListaId, nombre = nombre, isDefault = false)
     }
 }

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/login/data/repository/UserRepository.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/login/data/repository/UserRepository.kt
@@ -5,6 +5,7 @@ import dev.bonygod.listacompra.login.data.datasource.UsersDataSource
 import dev.bonygod.listacompra.login.domain.mapper.toDomain
 import dev.bonygod.listacompra.login.domain.model.Notifications
 import dev.bonygod.listacompra.login.domain.model.Usuario
+import dev.bonygod.listacompra.mislistas.domain.model.ListaInfo
 import kotlinx.coroutines.flow.Flow
 
 class UserRepository(
@@ -102,6 +103,40 @@ class UserRepository(
             usersDS.deleteAccount()
         } catch (e: Exception) {
             throw e.toUserFailure()
+        }
+    }
+
+    suspend fun getListas(): Result<List<ListaInfo>> {
+        return try {
+            Result.success(usersDS.getListas())
+        } catch (e: Exception) {
+            Result.failure(e.toUserFailure())
+        }
+    }
+
+    suspend fun setDefaultLista(listaId: String): Result<Unit> {
+        return try {
+            usersDS.setDefaultLista(listaId)
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e.toUserFailure())
+        }
+    }
+
+    suspend fun renameNombreLista(listaId: String, nombre: String): Result<Unit> {
+        return try {
+            usersDS.renameNombreLista(listaId, nombre)
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e.toUserFailure())
+        }
+    }
+
+    suspend fun addNewLista(nombre: String): Result<ListaInfo> {
+        return try {
+            Result.success(usersDS.addNewLista(nombre))
+        } catch (e: Exception) {
+            Result.failure(e.toUserFailure())
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/mislistas/domain/model/ListaInfo.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/mislistas/domain/model/ListaInfo.kt
@@ -1,0 +1,8 @@
+package dev.bonygod.listacompra.mislistas.domain.model
+
+data class ListaInfo(
+    val id: String,
+    val nombre: String,
+    val isDefault: Boolean
+)
+

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/mislistas/domain/usecase/AddNewListaUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/mislistas/domain/usecase/AddNewListaUseCase.kt
@@ -1,0 +1,10 @@
+package dev.bonygod.listacompra.mislistas.domain.usecase
+
+import dev.bonygod.listacompra.login.data.repository.UserRepository
+import dev.bonygod.listacompra.mislistas.domain.model.ListaInfo
+
+class AddNewListaUseCase(private val userRepository: UserRepository) {
+    suspend operator fun invoke(nombre: String): Result<ListaInfo> =
+        userRepository.addNewLista(nombre)
+}
+

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/mislistas/domain/usecase/GetListasUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/mislistas/domain/usecase/GetListasUseCase.kt
@@ -1,0 +1,10 @@
+﻿package dev.bonygod.listacompra.mislistas.domain.usecase
+import dev.bonygod.listacompra.login.data.repository.UserRepository
+import dev.bonygod.listacompra.mislistas.domain.model.ListaInfo
+class GetListasUseCase(
+    private val userRepository: UserRepository
+) {
+    suspend operator fun invoke(): Result<List<ListaInfo>> {
+        return userRepository.getListas()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/mislistas/domain/usecase/RenameListaUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/mislistas/domain/usecase/RenameListaUseCase.kt
@@ -1,0 +1,9 @@
+package dev.bonygod.listacompra.mislistas.domain.usecase
+
+import dev.bonygod.listacompra.login.data.repository.UserRepository
+
+class RenameListaUseCase(private val userRepository: UserRepository) {
+    suspend operator fun invoke(listaId: String, nombre: String): Result<Unit> =
+        userRepository.renameNombreLista(listaId, nombre)
+}
+

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/mislistas/domain/usecase/SetDefaultListaUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/mislistas/domain/usecase/SetDefaultListaUseCase.kt
@@ -1,0 +1,8 @@
+﻿package dev.bonygod.listacompra.mislistas.domain.usecase
+
+import dev.bonygod.listacompra.login.data.repository.UserRepository
+
+class SetDefaultListaUseCase(private val userRepository: UserRepository) {
+    suspend operator fun invoke(listaId: String): Result<Unit> =
+        userRepository.setDefaultLista(listaId)
+}

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/mislistas/ui/MisListasViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/mislistas/ui/MisListasViewModel.kt
@@ -1,0 +1,124 @@
+package dev.bonygod.listacompra.mislistas.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dev.bonygod.listacompra.core.navigation.Navigator
+import dev.bonygod.listacompra.core.navigation.Routes
+import dev.bonygod.listacompra.login.domain.usecase.GetUserUseCase
+import dev.bonygod.listacompra.mislistas.domain.usecase.AddNewListaUseCase
+import dev.bonygod.listacompra.mislistas.domain.usecase.GetListasUseCase
+import dev.bonygod.listacompra.mislistas.domain.usecase.RenameListaUseCase
+import dev.bonygod.listacompra.mislistas.domain.usecase.SetDefaultListaUseCase
+import dev.bonygod.listacompra.mislistas.ui.composables.interactions.MisListasEvent
+import dev.bonygod.listacompra.mislistas.ui.composables.interactions.MisListasState
+import dev.bonygod.listacompra.mislistas.ui.model.ListaInfoUI
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+class MisListasViewModel(
+    private val navigator: Navigator,
+    private val getListasUseCase: GetListasUseCase,
+    private val setDefaultListaUseCase: SetDefaultListaUseCase,
+    private val getUserUseCase: GetUserUseCase,
+    private val renameListaUseCase: RenameListaUseCase,
+    private val addNewListaUseCase: AddNewListaUseCase
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(MisListasState())
+    val state: StateFlow<MisListasState> = _state
+
+    private var userId: String = ""
+
+    fun loadListas() {
+        viewModelScope.launch {
+            _state.value = _state.value.copy(isLoading = true, error = null)
+            getUserUseCase().fold(
+                onSuccess = { user ->
+                    userId = user.uid
+                    getListasUseCase().fold(
+                        onSuccess = { listas ->
+                            _state.value = _state.value.copy(
+                                listas = listas.map {
+                                    ListaInfoUI(id = it.id, nombre = it.nombre, isDefault = it.isDefault)
+                                },
+                                isLoading = false
+                            )
+                        },
+                        onFailure = { e ->
+                            _state.value = _state.value.copy(
+                                isLoading = false,
+                                error = e.message ?: "Error al cargar las listas"
+                            )
+                        }
+                    )
+                },
+                onFailure = { e ->
+                    _state.value = _state.value.copy(
+                        isLoading = false,
+                        error = e.message ?: "Error al obtener el usuario"
+                    )
+                }
+            )
+        }
+    }
+
+    fun onEvent(event: MisListasEvent) {
+        when (event) {
+            is MisListasEvent.SelectLista -> selectLista(event.listaId)
+            is MisListasEvent.GoBack -> navigator.goBack()
+            is MisListasEvent.ShowRenameDialog -> _state.value = _state.value.copy(
+                renameDialogListaId = event.listaId,
+                renameDialogCurrentNombre = event.currentNombre
+            )
+            is MisListasEvent.ConfirmRename -> renameLista(event.listaId, event.nombre)
+            is MisListasEvent.ShowCreateDialog -> _state.value = _state.value.copy(showCreateDialog = true)
+            is MisListasEvent.ConfirmCreate -> createLista(event.nombre)
+            is MisListasEvent.DismissDialog -> _state.value = _state.value.copy(
+                renameDialogListaId = null,
+                renameDialogCurrentNombre = "",
+                showCreateDialog = false
+            )
+        }
+    }
+
+    private fun selectLista(listaId: String) {
+        viewModelScope.launch {
+            setDefaultListaUseCase(listaId).fold(
+                onSuccess = { navigator.clearAndNavigateTo(Routes.Home(userId)) },
+                onFailure = { e ->
+                    _state.value = _state.value.copy(error = e.message ?: "Error al seleccionar la lista")
+                }
+            )
+        }
+    }
+
+
+    private fun renameLista(listaId: String, nombre: String) {
+        viewModelScope.launch {
+            _state.value = _state.value.copy(
+                renameDialogListaId = null,
+                renameDialogCurrentNombre = ""
+            )
+            renameListaUseCase(listaId, nombre).fold(
+                onSuccess = { loadListas() },
+                onFailure = { e ->
+                    _state.value = _state.value.copy(error = e.message ?: "Error al renombrar la lista")
+                }
+            )
+        }
+    }
+
+    private fun createLista(nombre: String) {
+        viewModelScope.launch {
+            _state.value = _state.value.copy(showCreateDialog = false)
+            addNewListaUseCase(nombre).fold(
+                onSuccess = { loadListas() },
+                onFailure = { e ->
+                    _state.value = _state.value.copy(error = e.message ?: "Error al crear la lista")
+                }
+            )
+        }
+    }
+}
+

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/mislistas/ui/composables/MisListasContent.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/mislistas/ui/composables/MisListasContent.kt
@@ -1,0 +1,259 @@
+package dev.bonygod.listacompra.mislistas.ui.composables
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import dev.bonygod.listacompra.common.ui.theme.PrimaryBlue
+import dev.bonygod.listacompra.common.ui.theme.SecondaryBlue
+import dev.bonygod.listacompra.mislistas.ui.composables.interactions.MisListasEvent
+import dev.bonygod.listacompra.mislistas.ui.composables.interactions.MisListasState
+import dev.bonygod.listacompra.mislistas.ui.model.ListaInfoUI
+import listacompra.composeapp.generated.resources.Res
+import listacompra.composeapp.generated.resources.back_button
+import listacompra.composeapp.generated.resources.listas
+import org.jetbrains.compose.resources.painterResource
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MisListasContent(
+    state: MisListasState,
+    onEvent: (MisListasEvent) -> Unit
+) {
+    // Rename dialog
+    if (state.renameDialogListaId != null) {
+        NombreDialog(
+            title = "Renombrar lista",
+            initialNombre = state.renameDialogCurrentNombre,
+            confirmLabel = "Renombrar",
+            onConfirm = { nombre -> onEvent(MisListasEvent.ConfirmRename(state.renameDialogListaId, nombre)) },
+            onDismiss = { onEvent(MisListasEvent.DismissDialog) }
+        )
+    }
+
+    // Create dialog
+    if (state.showCreateDialog) {
+        NombreDialog(
+            title = "Nueva lista",
+            initialNombre = "",
+            confirmLabel = "Crear",
+            onConfirm = { nombre -> onEvent(MisListasEvent.ConfirmCreate(nombre)) },
+            onDismiss = { onEvent(MisListasEvent.DismissDialog) }
+        )
+    }
+
+    Scaffold(
+        containerColor = SecondaryBlue,
+        topBar = {
+            TopAppBar(
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = SecondaryBlue),
+                title = {
+                    Text(
+                        text = "Mis listas",
+                        fontWeight = FontWeight.Bold,
+                        color = Color.Black
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = { onEvent(MisListasEvent.GoBack) }) {
+                        Icon(
+                            painter = painterResource(Res.drawable.back_button),
+                            contentDescription = "Volver",
+                            tint = PrimaryBlue
+                        )
+                    }
+                }
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = { onEvent(MisListasEvent.ShowCreateDialog) },
+                containerColor = PrimaryBlue,
+                contentColor = Color.White,
+                shape = CircleShape
+            ) {
+                Text(text = "+", fontSize = 24.sp, fontWeight = FontWeight.Bold)
+            }
+        }
+    ) { paddingValues ->
+        when {
+            state.isLoading -> {
+                Box(
+                    modifier = Modifier.fillMaxSize().padding(paddingValues),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator(color = PrimaryBlue)
+                }
+            }
+
+            state.error != null -> {
+                Box(
+                    modifier = Modifier.fillMaxSize().padding(paddingValues).padding(16.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(text = state.error, color = Color.Red, fontSize = 16.sp)
+                }
+            }
+
+            state.listas.isEmpty() -> {
+                Box(
+                    modifier = Modifier.fillMaxSize().padding(paddingValues).padding(16.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(text = "No tienes listas disponibles", color = Color.Gray)
+                }
+            }
+
+            else -> {
+                LazyColumn(
+                    modifier = Modifier
+                        .padding(paddingValues)
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                ) {
+                    items(state.listas) { lista ->
+                        ListaItem(
+                            lista = lista,
+                            onSelect = { onEvent(MisListasEvent.SelectLista(lista.id)) },
+                            onRename = { onEvent(MisListasEvent.ShowRenameDialog(lista.id, lista.nombre)) }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun NombreDialog(
+    title: String,
+    initialNombre: String,
+    confirmLabel: String,
+    onConfirm: (String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    var nombre by remember { mutableStateOf(initialNombre) }
+    val focusRequester = remember { FocusRequester() }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(text = title, fontWeight = FontWeight.Bold) },
+        text = {
+            OutlinedTextField(
+                value = nombre,
+                onValueChange = { nombre = it },
+                label = { Text("Nombre") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth().focusRequester(focusRequester),
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                keyboardActions = KeyboardActions(onDone = {
+                    if (nombre.isNotBlank()) onConfirm(nombre.trim())
+                })
+            )
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { if (nombre.isNotBlank()) onConfirm(nombre.trim()) },
+                enabled = nombre.isNotBlank()
+            ) {
+                Text(confirmLabel, color = PrimaryBlue)
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancelar", color = Color.Gray)
+            }
+        }
+    )
+}
+
+@Composable
+private fun ListaItem(
+    lista: ListaInfoUI,
+    onSelect: () -> Unit,
+    onRename: () -> Unit
+) {
+    val shape = RoundedCornerShape(12.dp)
+    val borderColor = if (lista.isDefault) PrimaryBlue else Color.LightGray
+    val borderWidth = if (lista.isDefault) 2.dp else 1.dp
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 6.dp)
+            .border(width = borderWidth, color = borderColor, shape = shape)
+            .background(
+                color = if (lista.isDefault) SecondaryBlue else Color.White,
+                shape = shape
+            )
+            .clickable { onSelect() }
+            .padding(horizontal = 16.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            painter = painterResource(Res.drawable.listas),
+            contentDescription = null,
+            tint = PrimaryBlue,
+            modifier = Modifier.size(24.dp)
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = lista.nombre,
+                fontSize = 16.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = Color.Black
+            )
+            if (lista.isDefault) {
+                Text(
+                    text = "Predeterminada",
+                    fontSize = 12.sp,
+                    color = PrimaryBlue
+                )
+            }
+        }
+        // Rename button
+        IconButton(onClick = onRename) {
+            Text(text = "✏️", fontSize = 18.sp)
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/mislistas/ui/composables/interactions/MisListasEvent.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/mislistas/ui/composables/interactions/MisListasEvent.kt
@@ -1,0 +1,11 @@
+﻿package dev.bonygod.listacompra.mislistas.ui.composables.interactions
+
+sealed class MisListasEvent {
+    data class SelectLista(val listaId: String) : MisListasEvent()
+    data object GoBack : MisListasEvent()
+    data class ShowRenameDialog(val listaId: String, val currentNombre: String) : MisListasEvent()
+    data class ConfirmRename(val listaId: String, val nombre: String) : MisListasEvent()
+    data object ShowCreateDialog : MisListasEvent()
+    data class ConfirmCreate(val nombre: String) : MisListasEvent()
+    data object DismissDialog : MisListasEvent()
+}

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/mislistas/ui/composables/interactions/MisListasState.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/mislistas/ui/composables/interactions/MisListasState.kt
@@ -1,0 +1,12 @@
+﻿package dev.bonygod.listacompra.mislistas.ui.composables.interactions
+
+import dev.bonygod.listacompra.mislistas.ui.model.ListaInfoUI
+
+data class MisListasState(
+    val listas: List<ListaInfoUI> = emptyList(),
+    val isLoading: Boolean = true,
+    val error: String? = null,
+    val renameDialogListaId: String? = null,
+    val renameDialogCurrentNombre: String = "",
+    val showCreateDialog: Boolean = false
+)

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/mislistas/ui/model/ListaInfoUI.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/mislistas/ui/model/ListaInfoUI.kt
@@ -1,0 +1,6 @@
+﻿package dev.bonygod.listacompra.mislistas.ui.model
+data class ListaInfoUI(
+    val id: String = "",
+    val nombre: String = "",
+    val isDefault: Boolean = false
+)

--- a/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/mislistas/ui/screens/MisListasScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bonygod/listacompra/mislistas/ui/screens/MisListasScreen.kt
@@ -1,0 +1,19 @@
+package dev.bonygod.listacompra.mislistas.ui.screens
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import dev.bonygod.listacompra.mislistas.ui.MisListasViewModel
+import dev.bonygod.listacompra.mislistas.ui.composables.MisListasContent
+import org.koin.compose.viewmodel.koinViewModel
+@Composable
+fun MisListasScreen() {
+    val viewModel: MisListasViewModel = koinViewModel()
+    val state = viewModel.state.collectAsState()
+    LaunchedEffect(Unit) {
+        viewModel.loadListas()
+    }
+    MisListasContent(
+        state = state.value,
+        onEvent = viewModel::onEvent
+    )
+}

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -53,15 +53,11 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>


### PR DESCRIPTION
## Cambios incluidos en esta release

### ✨ Nueva funcionalidad — Mis Listas
- Pantalla "Mis Listas" con soporte para múltiples listas de la compra
- Crear nuevas listas con nombre personalizado (botón FAB `+`)
- Renombrar listas existentes (botón ✏️ por ítem)
- Seleccionar lista activa; la última seleccionada persiste entre sesiones
- Título de la Home se actualiza dinámicamente con el nombre de la lista activa
- Nombres almacenados en `usuarios/{uid}.nombresListas` para respetar reglas de Firestore

### 🐛 Fixes
- **Crash al cerrar sesión**: listener de notificaciones se detenía antes del logout para evitar `PERMISSION_DENIED`
- **Crash al aceptar lista compartida**: race condition corregida usando `loadUserData()` en lugar de asignar `_currentListaId` directamente; `.catch` añadido al flow de productos
- **Crash al renombrar lista**: escritura movida de `lista-compra/{id}` a `usuarios/{uid}.nombresListas` (permisos correctos)
- **Overload resolution ambiguity** en `MisListasViewModel` corregido

### 🎨 UI
- Color de lista activa cambiado a azul (`#3A86C2` / `#DAE5EE`)
- Eliminado icono de estrella; la selección de lista es suficiente como indicador
- Migración de `MisListasContent` a `Scaffold` con FAB

### 📱 iOS
- Deshabilitada la orientación landscape para evitar que el banner de AdMob se muestre en pantalla completa sin botón de cierre